### PR TITLE
Update Premium page to reflect Tebex market

### DIFF
--- a/src/docs/premium.mdx
+++ b/src/docs/premium.mdx
@@ -1,7 +1,7 @@
 ---
 slug: /premium
 title: Premium documentation
-description: Premium is a paid rank that helps fund the server and its development. Similarly to Patreon, subscribers pay 12.49 euro per month and get awesome perks as thanks for helping the server out. 
+description: Premium is a paid rank that helps fund the server and its development. Similarly to Patreon, supporters acquire a timed Premium package and get awesome perks as thanks for helping the server out. 
 sidebar_position: 97
 sidebar_label: Premium
 custom_edit_url: https://github.com/EarthMC/earthmc-docs/blob/main/src/docs/premium.mdx
@@ -10,7 +10,7 @@ custom_edit_url: https://github.com/EarthMC/earthmc-docs/blob/main/src/docs/prem
 
 [Here is the store page](https://store.earthmc.net/category/premium) if you are interested in buying premium. 
 
-Premium is a paid rank that helps fund the server and its development. It ensures thousands of players can play the server for free. At EarthMC we believe that players should not be able to pay for progress, something that sets us apart from most other large servers out there. Gold, the server’s currency, funds everything related to progress on the server. It’s therefore not possible to pay real money for gold. Instead, we offer convenience for those who chose to support the server through premium. Premium has many convenient features that could upgrade your EarthMC experience; 
+Premium is a paid rank that helps fund the server and its development. It ensures thousands of players can play the server for free. At EarthMC we believe that players should not have to pay for progress, something that sets us apart from most other large servers out there. Gold, the server’s currency, funds everything related to progress on the server. It’s therefore not possible to pay real money for gold. Instead, we offer convenience for those who chose to support the server through Premium. Premium has many convenient features that could upgrade your EarthMC experience; 
 
 ## Premium features
 
@@ -30,7 +30,7 @@ With Cloudflare Argo we’re able to offer you a premium network with up to 30% 
 Nation kings can change their map territory color from the default blue. The fill color and border color can be changed independently. Color options support predefined colors such as blue, yellow, red and green. It also supports any color in hex format for true color freedom. 
 
 ### Mystery crates
-A mystery crate contains one random cosmetic head item. It can be used for collecting and decoration. Everyone with premium receives 7 mystery crates every month. Mystery crates are also sold separately, 7 crates are worth 10 euro.
+A mystery crate contains one random cosmetic head item. It can be used for collecting and decoration. Everyone with premium receives a set amount of crates, depending on the purchased package. Mystery crates are also sold separately, 7 crates are worth € 10.
 
 ### Early access
 EarthMC is very conservative with map resets. At the time of writing there have only been two resets over the past 5 years. Players with premium get early access to new maps which normally lasts for a week. 
@@ -53,12 +53,12 @@ Gold username in chat, ability to change chat name, pink glow in hub, tab list p
 | /emcmap nationoutline | Change dynmap territory border-color
 
 ## Buy premium
-|   | 12 months | 6 months  | 1 month  |
-|---|---|---|---|
-| price | €59.99   | €44.99  | €8.99  |
-| Save | 44%  | 17%  |   |
-| Type | One-time  | One-time  | Subscription  |
+|   | 12 months | 3 months  |
+|---|---|---|
+| price | €59.99   | €29.99  |
+| Save | 50%  |  |
+| Type | One-time  | One-time  |
 
 [Click here to buy premium now](https://store.earthmc.net/category/premium)
 
-The price is in euro because EarthMC is operated from europe. The 1 month option is a subscription that can be canceled easily through your paypal dashboard or by clicking the cancel link in the payment confirmation email. We can also manually cancel it for you if you email contact@earthmc.net.
+The price is in € (Euro) because EarthMC is operated from Europe. For any inquiries regarding your Premium, please email contact@earthmc.net.


### PR DESCRIPTION
The tebex Market doesn't show subscriptions or 6-month Premium anymore. The Premium page in the docs should reflect this as well.